### PR TITLE
Fix bug tweeting company name as 'intent'

### DIFF
--- a/src/GoRemote/Model/JobspressoModel.php
+++ b/src/GoRemote/Model/JobspressoModel.php
@@ -53,7 +53,7 @@ class JobspressoModel implements \GoRemote\Model\SourceInterface
 			$jobClass->company->logo = (!empty($matches[1])) ? $matches[1] : '';			
 			$jobClass->company->name = (!empty($matches[2])) ? $matches[2] : $job->children('job_listing', true)->company;
 
-			preg_match('/href="?\'?(?:https?:)?\/\/(?:www\.)?twitter\.com\/(?!search)(?!jobspresso)(\w+)"?\'?/iu', $fc, $matches);
+			preg_match('/href="?\'?(?:https?:)?\/\/(?:www\.)?twitter\.com\/(?!search)(?!jobspresso)(?!intent)(\w+)"?\'?/iu', $fc, $matches);
 			$jobClass->company->twitter = (!empty($matches[1])) ? $matches[1] : '';
 
 			$jobs[] = $jobClass;


### PR DESCRIPTION
An annoying number of the tweets coming from the @goremoteio account start with "intent are looking for..." instead of using the correct company name "Amazon are looking for..."

A quick investigation suggests that the erroneous postings are coming from the jobspresso source.  It appears as if links like this:

    https://twitter.com/intent/tweet?original_referer=https%3A%2F%2Fgoremote.io%2Fjob%2F13333%2F&ref_src=twsrc%5Etfw&related=GoRemoteIo&text=Check%20out%20this%20job%20at%20%40intent&tw_p=tweetbutton&url=https%3A%2F%2Fgoremote.io%2Fjob%2F13333%2F&via=GoRemoteIo

(I copied that from one of the GoRemote pages, but I assume that the jobspresso target site has a similar 'Tweet this' button)

The parser is picking up the word 'intent' and assuming that it is the company's twitter account.  I assume that this also means your database contains tons of entries with the twitter account 'intent' associated with them.  This PR adjusts the regex to exclude the value 'intent' when grabbing a twitter account out of the jobspresso feed.  I don't know anything about PHP, nor have I tested this, so please be aware of that when applying.

Thanks!